### PR TITLE
Add API client, RND-4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,15 @@
     "test": "jest"
   },
   "dependencies": {
-    "@actions/core": "1.10.0"
+    "@actions/core": "1.10.0",
+    "@actions/http-client": "2.0.1"
   },
   "devDependencies": {
     "@types/node": "16.18.3",
     "@vercel/ncc": "0.34.0",
     "jest": "29.3.1",
     "js-yaml": "4.1.0",
+    "nock": "13.2.9",
     "prettier": "2.7.1",
     "ts-jest": "29.0.3",
     "typescript": "4.9.3"

--- a/src/client/apiClient.ts
+++ b/src/client/apiClient.ts
@@ -1,0 +1,87 @@
+import * as http from "@actions/http-client";
+import { StartSimulationRequest } from "./requests/startSimulationRequest";
+import { StartSimulationResponse } from "./responses/startSimulationResponse";
+import { TypedResponse } from "@actions/http-client/lib/interfaces";
+import { HttpClientError, HttpCodes } from "@actions/http-client";
+import { RunInformationResponse } from "./responses/runInformationResponse";
+import { SimulationResponse } from "./responses/simulationResponse";
+import { SeriesResponse } from "./responses/seriesResponse";
+import { RequestsSummaryResponse } from "./responses/requestsSummaryResponse";
+import { OutgoingHttpHeaders } from "http";
+
+export interface ApiClient {
+  startSimulation: (simulationId: string, options?: StartSimulationRequest) => Promise<StartSimulationResponse>;
+  getRunInformation: (runId: string) => Promise<RunInformationResponse>;
+  getSimulations: () => Promise<SimulationResponse[]>;
+  abortRun: (runId: string) => Promise<void>;
+  getUserConcurrentMetric: (runId: string, scenario: string) => Promise<SeriesResponse[]>;
+  getRequestsSummary: (runId: string) => Promise<RequestsSummaryResponse>;
+}
+
+export const apiClient = (): ApiClient => {
+  const client = new http.HttpClient();
+  const conf: HttpConf = {
+    // TODO RND-5 configurable
+    baseUrl: "https://cloud.gatling.io/api/public",
+    apiToken: ""
+  };
+  return {
+    startSimulation: (simulationId, options) =>
+      postJson(client, conf, "/simulations/start", options ?? {}, { simulation: simulationId }),
+    getRunInformation: (runId) => getJson(client, conf, "/run", { run: runId }),
+    getSimulations: () => getJson(client, conf, "/simulations"),
+    abortRun: (runId) => postJson(client, conf, "/simulations/abort", {}, { run: runId }),
+    getUserConcurrentMetric: (runId, scenario) => getJson(client, conf, "/series", seriesParams(runId, scenario)),
+    getRequestsSummary: (runId) => getJson(client, conf, "/summaries/requests", { run: runId })
+  };
+};
+
+interface HttpConf {
+  baseUrl: string;
+  apiToken: string;
+}
+
+const seriesParams = (runId: string, scenario: string) => ({
+  run: runId,
+  scenario: scenario,
+  group: "",
+  request: "",
+  node: "",
+  remote: "",
+  metric: "usrActive"
+});
+
+const getJson = async <T>(
+  client: http.HttpClient,
+  conf: HttpConf,
+  path: string,
+  params?: Record<string, string>
+): Promise<T> => client.getJson<T>(buildUrl(conf, path, params), headers(conf)).then(handleJsonResponse);
+
+const postJson = async <T>(
+  client: http.HttpClient,
+  conf: HttpConf,
+  path: string,
+  payload: any,
+  params?: Record<string, string>
+): Promise<T> => client.postJson<T>(buildUrl(conf, path, params), payload, headers(conf)).then(handleJsonResponse);
+
+const headers = (conf: HttpConf): OutgoingHttpHeaders => ({ Authorization: conf.apiToken });
+
+const buildUrl = (conf: HttpConf, path: string, queryParams?: Record<string, string>): string => {
+  const resourceUrl = conf.baseUrl + path;
+  const url = new URL(resourceUrl);
+  if (queryParams) {
+    for (const [key, value] of Object.entries(queryParams)) {
+      url.searchParams.append(key, value);
+    }
+  }
+  return url.toString();
+};
+
+const handleJsonResponse = <T>(response: TypedResponse<T>): T => {
+  if (response.statusCode === HttpCodes.NotFound || response.result === null) {
+    throw new HttpClientError("Unexpected empty response", HttpCodes.NotFound);
+  }
+  return response.result;
+};

--- a/src/client/requests/startSimulationRequest.ts
+++ b/src/client/requests/startSimulationRequest.ts
@@ -1,0 +1,10 @@
+export interface StartSimulationRequest {
+  extraSystemProperties?: Record<string, string>;
+  extraEnvironmentVariables?: Record<string, string>;
+  overrideHostsByPool?: Record<string, StartHostConfigurationRequest>;
+}
+
+export interface StartHostConfigurationRequest {
+  size: number;
+  weight?: number;
+}

--- a/src/client/responses/requestsSummaryResponse.ts
+++ b/src/client/responses/requestsSummaryResponse.ts
@@ -1,0 +1,41 @@
+export interface RequestsSummaryResponse {
+  name: string;
+  responseTime: ResponseTimeRequestsSummary;
+  in: InRequestsSummary;
+  out: OutRequestsSummary;
+  children: RequestsSummaryChild[];
+}
+
+export interface RequestsSummaryChild {
+  name: string;
+  index: number;
+  incrementalId: number;
+  responseTime: ResponseTimeRequestsSummary;
+  in: InRequestsSummary;
+  out: OutRequestsSummary;
+}
+
+export interface ResponseTimeRequestsSummary {
+  mean: number;
+  stdDev: number;
+  percentiles: number[];
+}
+
+export interface InRequestsSummary {
+  counts: {
+    ok: number;
+    ko: number;
+    koPercent: number;
+    total: number;
+  };
+  rps: {
+    ok: number;
+    ko: number;
+    total: number;
+  };
+}
+
+export interface OutRequestsSummary {
+  counts: { total: number };
+  rps: { total: number };
+}

--- a/src/client/responses/runInformationResponse.ts
+++ b/src/client/responses/runInformationResponse.ts
@@ -1,0 +1,40 @@
+export interface RunInformationResponse {
+  incrementalId: number;
+  runId: string;
+  scenario: string;
+  group: string;
+  request: string;
+  buildStart: number;
+  buildEnd: number;
+  deployStart: number;
+  deployEnd: number;
+  injectStart: number;
+  injectEnd: number;
+  status: number;
+  assertions: Assertion[];
+  error?: string;
+  comments: Comment;
+  runSnapshot: RunSnapshot;
+}
+
+export interface Assertion {
+  message: string;
+  result: boolean;
+  actualValue?: number;
+}
+
+export interface Comment {
+  title: string;
+  description: string;
+}
+
+export interface RunSnapshot {
+  simulationName: string;
+  systemProperties: Record<string, string>;
+  simulationClass: string;
+  poolSnapshots: PoolSnapshot[];
+}
+
+export interface PoolSnapshot {
+  poolName: string;
+}

--- a/src/client/responses/seriesResponse.ts
+++ b/src/client/responses/seriesResponse.ts
@@ -1,0 +1,3 @@
+export interface SeriesResponse {
+  values: number[];
+}

--- a/src/client/responses/simulationResponse.ts
+++ b/src/client/responses/simulationResponse.ts
@@ -1,0 +1,4 @@
+export interface SimulationResponse {
+  id: string;
+  name: string;
+}

--- a/src/client/responses/startSimulationResponse.ts
+++ b/src/client/responses/startSimulationResponse.ts
@@ -1,0 +1,6 @@
+export interface StartSimulationResponse {
+  className: string;
+  runId: string;
+  reportsPath: string;
+  runsPath: string;
+}

--- a/test/client/apiClient.test.ts
+++ b/test/client/apiClient.test.ts
@@ -1,0 +1,48 @@
+import { apiClient } from "../../src/client/apiClient";
+import nock from "nock";
+import { expect, test } from "@jest/globals";
+import { StartSimulationResponse } from "../../src/client/responses/startSimulationResponse";
+import { HttpClientError } from "@actions/http-client";
+
+const client = apiClient();
+
+const simulation_id = "3e5d7e20-53c2-40ba-b0a2-0b0d93b33287";
+const simulation_start_expected_url = `/api/public/simulations/start?simulation=${simulation_id}`;
+
+const successfulStartedSimulationResponse: StartSimulationResponse = {
+  className: "computerdatabase.ComputerDatabaseSimulation",
+  runId: "bd4e73bb-ac41-4786-ade6-6ce7f26e7fb2",
+  reportsPath: "/o/demo-environment/simulations/reports/bd4e73bb-ac41-4786-ade6-6ce7f26e7fb2",
+  runsPath: "/o/demo-environment/simulations/runs/3e5d7e20-53c2-40ba-b0a2-0b0d93b33287"
+};
+
+const unauthorizedResponse = {
+  error: "invalid_request",
+  error_description: "i.g.f.a.s.UnauthorizedException$: Access unauthorized"
+};
+
+test("startSimulation success", async () => {
+  nock("https://cloud.gatling.io").post(simulation_start_expected_url).reply(200, successfulStartedSimulationResponse);
+
+  const actualResponse = await client.startSimulation(simulation_id);
+  expect(actualResponse).toStrictEqual(successfulStartedSimulationResponse);
+});
+
+test("startSimulation unauthorized error", async () => {
+  nock("https://cloud.gatling.io").post(simulation_start_expected_url).reply(401, unauthorizedResponse);
+
+  const request = client.startSimulation(simulation_id);
+  await expect(request).rejects.toStrictEqual(
+    new HttpClientError(
+      '{"error":"invalid_request","error_description":"i.g.f.a.s.UnauthorizedException$: Access unauthorized"}',
+      401
+    )
+  );
+});
+
+test("startSimulation not found error", async () => {
+  nock("https://cloud.gatling.io").post(simulation_start_expected_url).reply(404);
+
+  const request = client.startSimulation(simulation_id);
+  await expect(request).rejects.toStrictEqual(new HttpClientError("Unexpected empty response", 404));
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./src",
+    "lib": ["ES2021"],
+    "module": "CommonJS",
+    "target": "ES2021",
+    "esModuleInterop": true,
     "strict": true,
-    "noImplicitAny": true,
-    "esModuleInterop": true
+    "forceConsistentCasingInFileNames": true
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@actions/http-client" "^2.0.1"
     uuid "^8.3.2"
 
-"@actions/http-client@^2.0.1":
+"@actions/http-client@2.0.1", "@actions/http-client@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-2.0.1.tgz#873f4ca98fe32f6839462a6f046332677322f99c"
   integrity sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==
@@ -1661,6 +1661,11 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
+
 json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
@@ -1692,6 +1697,11 @@ lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -1753,6 +1763,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+nock@13.2.9:
+  version "13.2.9"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.9.tgz#4faf6c28175d36044da4cfa68e33e5a15086ad4c"
+  integrity sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+    propagate "^2.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -1889,6 +1909,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 react-is@^18.0.0:
   version "18.2.0"


### PR DESCRIPTION
This API client's functions directly map to API endpoints. In the existing CI plugins, the HTTP client also includes a bunch of code for computing a metrics summary based on the result of several API calls - here, I've extracted that code from the client and will include it in a separate pull request.

I've also removed some fields we won't use from the types of the responses, we can probably remove more.

We could also add validations for the responses with a lib such as [idonttrustlikethat](https://github.com/AlexGalays/idonttrustlikethat), to make sure we fail fast if we break something in the API or the responses models, but it's not required right now.