### PR TITLE
chore: Set up Dependabot updates, RND-9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    ignore:
+      # the major version for Node should match the runtime configured in action.yml
+      - dependency-name: "@types/node"
+        update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
Configure automatic dependency update pull requests with Dependabot. Notes:
- From what I understand, when using Yarn, ecosystem is `npm` but Dependabot should detect the `yarn.lock` file and understand it's a Yarn project.
- Update schedule is the same we use for Scala Steward.