### PR TITLE
chore: Configure Dependabot to update GH actions used in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    labels:
+      - "dependencies"
+      - "npm"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -9,3 +12,13 @@ updates:
       # the major version for Node should match the runtime configured in action.yml
       - dependency-name: "@types/node"
         update-types: [ "version-update:semver-major" ]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    schedule:
+      interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
Motivation:

We already use Dependabot to keep the project dependencies up to date. We'd like to keep the actions used in our workflows up to date too.

Modifications:

- Configure Dependabot for "github-actions" exosystem
- Add a prefix for Dependabot's pull requests

Result:

Actions used in workflows checked for updates once a week.