### PR TITLE
fix: Properly handle reports and runs history URLs with GE Self-Hosted

### DIFF
--- a/src/run/start.ts
+++ b/src/run/start.ts
@@ -3,8 +3,8 @@ import { ActionConfig } from "../config";
 
 export interface StartedRun {
   runId: string;
-  reportsUrl?: string;
-  runsUrl?: string;
+  reportsUrl: string;
+  runsUrl: string;
 }
 
 export const startRun = async (client: ApiClient, config: ActionConfig): Promise<StartedRun> => {
@@ -14,10 +14,15 @@ export const startRun = async (client: ApiClient, config: ActionConfig): Promise
     overrideHostsByPool: config.run.overrideLoadGenerators
   });
 
-  const reportsUrl = webAppUrl(config, response.reportsPath);
-  const runsUrl = webAppUrl(config, response.runsPath);
-  return { runId: response.runId, reportsUrl, runsUrl };
+  // Fallback URLs for Gatling Enterprise Self-Hosted
+  const reportsPath = response.reportsPath ?? `/simulations/reports/${response.runId}`;
+  const runsPath = response.runsPath ?? `/simulations/runs/${config.run.simulationId}`;
+
+  return {
+    runId: response.runId,
+    reportsUrl: webAppUrl(config, reportsPath),
+    runsUrl: webAppUrl(config, runsPath)
+  };
 };
 
-const webAppUrl = (config: ActionConfig, path?: string): string | undefined =>
-  path ? config.gatlingEnterpriseUrl + path : undefined;
+const webAppUrl = (config: ActionConfig, path: string): string => config.gatlingEnterpriseUrl + path;

--- a/src/runMain.ts
+++ b/src/runMain.ts
@@ -44,12 +44,8 @@ const run = async (): Promise<void> => {
 
 const logStart = (config: ActionConfig, startedRun: StartedRun): void => {
   log(bright(`Started run ${startedRun.runId} for simulation ${config.run.simulationId}`));
-  if (startedRun.reportsUrl) {
-    annotateNotice(`Run reports will be available at ${startedRun.reportsUrl}`, "Gatling Enterprise reports");
-  }
-  if (startedRun.runsUrl) {
-    annotateNotice(`Runs history is available at ${startedRun.runsUrl}`, "Gatling Enterprise runs history");
-  }
+  annotateNotice(`Run reports will be available at ${startedRun.reportsUrl}`, "Gatling Enterprise reports");
+  annotateNotice(`Runs history is available at ${startedRun.runsUrl}`, "Gatling Enterprise runs history");
   log("");
 };
 
@@ -92,12 +88,8 @@ const logResult = (config: ActionConfig, startedRun: StartedRun, finishedRun: Fi
   }
 
   log("");
-  if (startedRun.reportsUrl) {
-    log(bright(`See the run reports at ${startedRun.reportsUrl}`));
-  }
-  if (startedRun.runsUrl) {
-    log(bright(`See the runs history at ${startedRun.runsUrl}`));
-  }
+  log(bright(`See the run reports at ${startedRun.reportsUrl}`));
+  log(bright(`See the runs history at ${startedRun.runsUrl}`));
 };
 
 export default run;


### PR DESCRIPTION
Motivation:

Gatling Enterprise Self-Hosted doesn't return the reports and runs history URLs in the run start response.

Modifications:

When missing from the response, generate these URLs using hard-coded paths valid for Gatling Enterprise Self-Hosted

Result:

The action prints the reports URL and runs history URL correctly when used with Gatling Enterprise Self-Hosted