### PR TITLE
fix: Properly format run_assertions output for Docker runner

### DIFF
--- a/docker/src/output.ts
+++ b/docker/src/output.ts
@@ -3,6 +3,16 @@ import path from "path";
 
 import { Output, Logger, utils } from "@gatling-enterprise-runner/common";
 
+const toOutputString = (value: any): String => {
+  if (value === null || value === undefined) {
+    return "";
+  } else if (typeof value === "string" || value instanceof String) {
+    return value;
+  } else {
+    return JSON.stringify(value);
+  }
+};
+
 export const dotEnvOutput = async (logger: Logger, dotEnvOutputPath?: string): Promise<Output> => {
   if (dotEnvOutputPath) {
     try {
@@ -15,12 +25,12 @@ export const dotEnvOutput = async (logger: Logger, dotEnvOutputPath?: string): P
       throw new Error(`Unable to write outputs to '${dotEnvOutputPath}', cause by: ${utils.formatErrorMessage(e)}`);
     }
     return {
-      set: (name, value) => fs.appendFile(dotEnvOutputPath, `${name}=${value}\n`, "utf8")
+      set: (name, value) => fs.appendFile(dotEnvOutputPath, `${name}=${toOutputString(value)}\n`, "utf8")
     };
   } else {
     logger.log("No output file configured, outputs will be ignored");
     return {
-      set: async (name, value) => logger.debug(`Ignored output: ${name}=${value}`)
+      set: async (name, value) => logger.debug(`Ignored output: ${name}=${toOutputString(value)}`)
     };
   }
 };


### PR DESCRIPTION
Motivation:

With the Docker runner, the run_assertions output is not properly formatted as JSON.

Modifications:

In the Docker runner's output, if a value isn't a string (or null/undefined), format it as JSON (similar to what is done by default with the GitHub Action outputs).