### PR TITLE
feat: Add support for separate API URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'URL of your Gatling Enterprise server (needed only for self-hosted instances).'
     required: false
     default: 'https://cloud.gatling.io'
+  gatling_enterprise_api_url:
+    description: 'Allows configuring a separate URL for the Gatling Enterprise API, this is NOT required for typical use cases.'
+    required: false
   api_token:
     description: 'A Gatling Enterprise API token with at least Start permission (we recommend storing it securely using GitHub''s encrypted secrets; see https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow). Alternatively, you can define your token in an environment variable named GATLING_ENTERPRISE_API_TOKEN.'
     required: false

--- a/common/test/client/apiClient.test.ts
+++ b/common/test/client/apiClient.test.ts
@@ -5,7 +5,7 @@ import { StartSimulationResponse } from "@src/client/responses/startSimulationRe
 import { HttpClientError } from "@actions/http-client";
 
 const config: ApiClientConfig = {
-  baseUrl: "https://cloud.gatling.io/api/public",
+  baseUrl: "https://api.gatling.io/api/public",
   apiToken: "my-token"
 };
 const client = apiClient(config);

--- a/docker/src/config.ts
+++ b/docker/src/config.ts
@@ -8,9 +8,10 @@ export interface DockerConfig extends config.Config {
 
 export const readConfig = (logger: Logger): DockerConfig => {
   const gatlingEnterpriseUrl = getGatlingEnterpriseUrlConfig();
+  const apiUrl = getApiUrlConfig(gatlingEnterpriseUrl);
   const config = {
     gatlingEnterpriseUrl,
-    api: getApiConfig(gatlingEnterpriseUrl),
+    api: getApiConfig(apiUrl),
     run: getRunConfig(),
     failActionOnRunFailure: getFailActionOnRunFailureConfig(),
     waitForRunEnd: getWaitForRunEnd(),
@@ -28,6 +29,15 @@ const getGatlingEnterpriseUrlConfig = (): string =>
     "GATLING_ENTERPRISE_URL is required",
     "https://cloud.gatling.io"
   );
+
+const getApiUrlConfig = (gatlingEnterpriseUrl: string): string => {
+  const configuredValue = getValidatedInput("GATLING_ENTERPRISE_API_URL", config.optionalInputValidation, "");
+  return configuredValue !== undefined
+    ? configuredValue
+    : gatlingEnterpriseUrl === "https://cloud.gatling.io"
+      ? "https://api.gatling.io"
+      : gatlingEnterpriseUrl;
+};
 
 const getOutputDotEnvPath = (): string | undefined =>
   getValidatedInput("OUTPUT_DOT_ENV_FILE_PATH", config.optionalInputValidation, "");
@@ -70,14 +80,14 @@ const getRunSummaryLoggingConfiguration = (): config.RunSummaryLoggingConfigurat
   return { enabled, initialRefreshInterval, initialRefreshCount, refreshInterval };
 };
 
-const getApiConfig = (gatlingEnterpriseUrl: string): ApiClientConfig => {
+const getApiConfig = (apiUrl: string): ApiClientConfig => {
   const apiToken = getValidatedInput(
     "GATLING_ENTERPRISE_API_TOKEN",
     config.requiredInputValidation,
     "GATLING_ENTERPRISE_API_TOKEN is required"
   );
   return {
-    baseUrl: `${gatlingEnterpriseUrl}/api/public`,
+    baseUrl: `${apiUrl}/api/public`,
     apiToken
   };
 };

--- a/gh-action/src/config.ts
+++ b/gh-action/src/config.ts
@@ -5,9 +5,10 @@ import { ApiClientConfig, config, Logger } from "@gatling-enterprise-runner/comm
 
 export const readConfig = (logger: Logger): config.Config => {
   const gatlingEnterpriseUrl = getGatlingEnterpriseUrlConfig();
+  const apiUrl = getApiUrlConfig(gatlingEnterpriseUrl);
   const config = {
     gatlingEnterpriseUrl,
-    api: getApiConfig(gatlingEnterpriseUrl),
+    api: getApiConfig(apiUrl),
     run: getRunConfig(),
     failActionOnRunFailure: getFailActionOnRunFailureConfig(),
     waitForRunEnd: getWaitForRunEnd(),
@@ -19,6 +20,15 @@ export const readConfig = (logger: Logger): config.Config => {
 
 const getGatlingEnterpriseUrlConfig = (): string =>
   getValidatedInput("gatling_enterprise_url", config.requiredInputValidation, "gatling_enterprise_url is required");
+
+const getApiUrlConfig = (gatlingEnterpriseUrl: string): string => {
+  const configuredValue = getValidatedInput("gatling_enterprise_api_url", config.optionalInputValidation, "");
+  return configuredValue !== undefined
+    ? configuredValue
+    : gatlingEnterpriseUrl === "https://cloud.gatling.io"
+      ? "https://api.gatling.io"
+      : gatlingEnterpriseUrl;
+};
 
 const getFailActionOnRunFailureConfig = (): boolean =>
   getValidatedInput(
@@ -50,7 +60,7 @@ const getRunSummaryLoggingConfiguration = (): config.RunSummaryLoggingConfigurat
   return { enabled, initialRefreshInterval, initialRefreshCount, refreshInterval };
 };
 
-const getApiConfig = (gatlingEnterpriseUrl: string): ApiClientConfig => {
+const getApiConfig = (apiUrl: string): ApiClientConfig => {
   const apiToken = getValidatedInput(
     "api_token",
     config.requiredInputValidation,
@@ -58,7 +68,7 @@ const getApiConfig = (gatlingEnterpriseUrl: string): ApiClientConfig => {
     "GATLING_ENTERPRISE_API_TOKEN"
   );
   return {
-    baseUrl: `${gatlingEnterpriseUrl}/api/public`,
+    baseUrl: `${apiUrl}/api/public`,
     apiToken
   };
 };


### PR DESCRIPTION
- By default, use api.gatling.io for the API URL and cloud.gatling.io for the web app URL.
- When configuring a web URL different from cloud.gatling.io, default to using the same URL for the API, as expected for self-hosted users.
- Allow separately configuring the API URL if needed, which should only be useful for testing in our non-production environments.