### PR TITLE
feat: Add Harness plugin

### DIFF
--- a/docker/src/config.ts
+++ b/docker/src/config.ts
@@ -124,7 +124,9 @@ const getValidatedInput = <T>(
   defaultValue?: string
 ) => {
   const effectiveDefault = defaultValue ?? "";
-  const rawInput = process.env[envVarName] ?? effectiveDefault;
+
+  // The PLUGIN_ prefix is used to pass env values to Harness
+  const rawInput = process.env[envVarName] ?? process.env[`PLUGIN_${envVarName}`] ?? effectiveDefault;
   const result = validator.validate(rawInput);
   if (!result.ok) {
     // TODO RND-10 use validation error result to give better error messages


### PR DESCRIPTION
In the [harness documentation plugin](https://developer.harness.io/docs/continuous-integration/use-ci/use-drone-plugins/custom_plugins/#variables-in-plugin-scripts), we need to prefix env variable by PLUGIN_

This PR, adds a system to support this in the Docker image.


