### PR TITLE
feat: Add configuration keys for run title and description

### DIFF
--- a/.github/workflows/run-enterprise-action.yml
+++ b/.github/workflows/run-enterprise-action.yml
@@ -15,6 +15,12 @@ on:
       override_load_generators:
         type: string
         required: false
+      title:
+        type: string
+        required: false
+      description:
+        type: string
+        required: false
       fail_action_on_run_failure:
         type: boolean
         default: 'true'
@@ -55,6 +61,8 @@ jobs:
           extra_system_properties: ${{ inputs.extra_system_properties }}
           extra_environment_variables: ${{ inputs.extra_environment_variables }}
           override_load_generators: ${{ inputs.override_load_generators }}
+          title: ${{ inputs.title }}
+          description: ${{ inputs.description }}
           fail_action_on_run_failure: ${{ inputs.fail_action_on_run_failure }}
           wait_for_run_end: ${{ inputs.wait_for_run_end }}
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,12 @@ inputs:
   override_load_generators:
     description: 'Overrides the simulation''s load generators configuration. Must be formatted as a JSON object, e.g. {"4a399023-d443-3a58-864f-3919760df78b":{"size":1,"weight":60},"c800b6d9-163b-3db7-928f-86c1470a9542":{"size":1,"weight":40}} (weights are optional).'
     required: false
+  title:
+    description: 'Give a title to the run started by this action.'
+    required: false
+  description:
+    description: 'Give a description to the run started by this action.'
+    required: false
   fail_action_on_run_failure:
     description: 'Whether the action should fail if the run ends with a failed status. True by default. If set to false, some of this action''s outputs may be missing.'
     required: false

--- a/common/src/client/requests/startSimulationRequest.ts
+++ b/common/src/client/requests/startSimulationRequest.ts
@@ -2,6 +2,8 @@ export interface StartSimulationRequest {
   extraSystemProperties?: Record<string, string>;
   extraEnvironmentVariables?: Record<string, string>;
   overrideHostsByPool?: Record<string, StartHostConfigurationRequest>;
+  title?: string;
+  description?: string;
 }
 
 export interface StartHostConfigurationRequest {

--- a/common/src/config.ts
+++ b/common/src/config.ts
@@ -15,6 +15,8 @@ export interface RunConfig {
   extraSystemProperties?: Record<string, string>;
   extraEnvironmentVariables?: Record<string, string>;
   overrideLoadGenerators?: Record<string, LoadGeneratorConfiguration>;
+  title?: string;
+  description?: string;
 }
 
 export interface LoadGeneratorConfiguration {

--- a/common/src/run/start.ts
+++ b/common/src/run/start.ts
@@ -11,7 +11,9 @@ export const startRun = async (client: ApiClient, config: Config): Promise<Start
   const response = await client.startSimulation(config.run.simulationId, {
     extraSystemProperties: config.run.extraSystemProperties,
     extraEnvironmentVariables: config.run.extraEnvironmentVariables,
-    overrideHostsByPool: config.run.overrideLoadGenerators
+    overrideHostsByPool: config.run.overrideLoadGenerators,
+    title: config.run.title,
+    description: config.run.description
   });
 
   // Fallback URLs for Gatling Enterprise Self-Hosted

--- a/docker/src/config.ts
+++ b/docker/src/config.ts
@@ -109,11 +109,23 @@ const getRunConfig = (): config.RunConfig => {
     config.overrideLoadGeneratorsInputValidation,
     "OVERRIDE_LOAD_GENERATORS must be a valid configuration for overriding load generators"
   );
+  const title = getValidatedInput(
+    "TITLE",
+    config.optionalInputValidation,
+    "TITLE must be a string (or omitted entirely)"
+  );
+  const description = getValidatedInput(
+    "DESCRIPTION",
+    config.optionalInputValidation,
+    "DESCRIPTION must be a string (or omitted entirely)"
+  );
   return {
     simulationId,
     extraSystemProperties,
     extraEnvironmentVariables,
-    overrideLoadGenerators: overrideLoadGenerators
+    overrideLoadGenerators,
+    title,
+    description
   };
 };
 

--- a/gh-action/src/config.ts
+++ b/gh-action/src/config.ts
@@ -90,11 +90,23 @@ const getRunConfig = (): config.RunConfig => {
     config.overrideLoadGeneratorsInputValidation,
     "override_load_generators must be a valid configuration for overriding load generators"
   );
+  const title = getValidatedInput(
+    "title",
+    config.optionalInputValidation,
+    "title must be a string (or omitted entirely)"
+  );
+  const description = getValidatedInput(
+    "description",
+    config.optionalInputValidation,
+    "description must be a string (or omitted entirely)"
+  );
   return {
     simulationId,
     extraSystemProperties,
     extraEnvironmentVariables,
-    overrideLoadGenerators: overrideLoadGenerators
+    overrideLoadGenerators,
+    title,
+    description
   };
 };
 


### PR DESCRIPTION
Motivation:

The build tool plugins already allow configuring a title and description, but the GH Action/Docker image do not.

Modifications:

Add the title and description configuration keys and pass them to the public API when starting a run.

Result:

Users can configure a title and a description for each run.